### PR TITLE
ViolationsState: Fix sorting license expressions

### DIFF
--- a/src/main/kotlin/state/ViolationsState.kt
+++ b/src/main/kotlin/state/ViolationsState.kt
@@ -16,6 +16,7 @@ import org.ossreviewtoolkit.model.utils.ResolutionProvider
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 import org.ossreviewtoolkit.workbench.util.OrtResultApi
 import org.ossreviewtoolkit.workbench.util.ResolutionStatus
+import org.ossreviewtoolkit.workbench.util.SpdxExpressionStringComparator
 
 class ViolationsState {
     var initialized by mutableStateOf(false)
@@ -70,7 +71,8 @@ class ViolationsState {
         _identifiers += _violations.mapNotNullTo(sortedSetOf()) { it.pkg }.toList()
 
         _licenses.clear()
-        _licenses += _violations.mapNotNullTo(sortedSetOf()) { it.license }.toList()
+        _licenses += _violations.mapNotNullTo(sortedSetOf(comparator = SpdxExpressionStringComparator())) { it.license }
+            .toList()
 
         _rules.clear()
         _rules += _violations.mapTo(sortedSetOf()) { it.rule }.toList()

--- a/src/main/kotlin/util/SpdxExpressionStringComparator.kt
+++ b/src/main/kotlin/util/SpdxExpressionStringComparator.kt
@@ -1,0 +1,8 @@
+package org.ossreviewtoolkit.workbench.util
+
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression
+
+class SpdxExpressionStringComparator : Comparator<SpdxExpression> {
+    override fun compare(left: SpdxExpression?, right: SpdxExpression?): Int =
+        compareValues(left?.toString(), right?.toString())
+}


### PR DESCRIPTION
Add a string comparator for `SpdxExpression` to fix sorting license
expressions.